### PR TITLE
Changed default to E4s instead of E8s for vm size

### DIFF
--- a/CreateLabUsersAndResources.ps1
+++ b/CreateLabUsersAndResources.ps1
@@ -86,7 +86,7 @@ $users | ForEach-Object{[PSCustomObject]$_} | Format-Table
 $users | ForEach-Object{[PSCustomObject]$_} | Export-CSV "user_credentials.csv"
 
 While ((Get-Job | Where-Object {$_.State -ne "Completed" -and $_.State -ne "Failed" -and $_.State -ne "Stopped"} | Measure-Object).Count -gt 0) {
-    Write-Host "$((Get-AzDeployment | Where-Object {$_.ProvisioningState -eq "Provisioning"} | Measure-Object).Count) Still Running"
+    Write-Host "$((Get-AzDeployment | Where-Object {$_.ProvisioningState -eq "Running"} | Measure-Object).Count) Still Running"
     Write-Host "$((Get-AzDeployment | Where-Object {$_.ProvisioningState -eq "Failed"} | Measure-Object).Count) Have Failed"
     Start-Sleep -Seconds 60
 }

--- a/labvm.bicep
+++ b/labvm.bicep
@@ -7,7 +7,7 @@ param location string = resourceGroup().location
 param vmName string
 
 @description('Default VM Size')
-param vmSize string = 'Standard_E8s_v4'
+param vmSize string = 'Standard_E4s_v4'
 
 @description('Enter user name, this will be your VM Login, SQL DB Admin, and SQL MI Admin')
 param administratorLogin string

--- a/single_subscription_user_deployment.bicep
+++ b/single_subscription_user_deployment.bicep
@@ -11,7 +11,7 @@ param networkRgName string = 'SQLMigrationLab'
 param location string
 
 @description('Default VM Size')
-param vmSize string = 'Standard_E8s_v4'
+param vmSize string = 'Standard_E4s_v4'
 
 @description('Enter the SQL DB Database name.')
 param sqlDBDatabaseName string = 'SqlMigrationLab'


### PR DESCRIPTION
Changed the default size of the VM to prevent needing core quota for a large group.

Properly querying Get-AzDeployment to get currently running deployments.